### PR TITLE
Use last memory_cost  if fetch fails

### DIFF
--- a/miner.py
+++ b/miner.py
@@ -85,7 +85,7 @@ def fetch_difficulty_from_server():
         return str(response_data['difficulty'])
     except Exception as e:
         print(f"An error occurred while fetching difficulty: {e}")
-        return '2000'  # Default value if fetching fails
+        return memory_cost  # Return last value if fetching fails
 
 def generate_random_sha256(max_length=128):
     characters = string.ascii_letters + string.digits + string.punctuation


### PR DESCRIPTION
If fetching fails, memory cost start jumping from last value > 2000 > updated value
In most cases, the memory_cost remains the same as before, so I consider that it is better to use the last received value if fetching fails